### PR TITLE
Viewport aware components

### DIFF
--- a/demo/src/main/java/com/otaliastudios/opengl/demo/MainActivity.kt
+++ b/demo/src/main/java/com/otaliastudios/opengl/demo/MainActivity.kt
@@ -4,7 +4,6 @@ import android.animation.ValueAnimator
 import android.graphics.Color
 import android.graphics.RectF
 import android.opengl.GLES20
-import android.opengl.Matrix
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.Handler
@@ -15,10 +14,6 @@ import com.otaliastudios.opengl.core.EglCore
 import com.otaliastudios.opengl.draw.GlCircle
 import com.otaliastudios.opengl.draw.GlRect
 import com.otaliastudios.opengl.draw.GlTriangle
-import com.otaliastudios.opengl.extensions.clear
-import com.otaliastudios.opengl.extensions.makeIdentity
-import com.otaliastudios.opengl.extensions.scaleX
-import com.otaliastudios.opengl.extensions.scaleY
 import com.otaliastudios.opengl.program.GlFlatProgram
 import com.otaliastudios.opengl.scene.GlScene
 import com.otaliastudios.opengl.surface.EglWindowSurface
@@ -61,15 +56,7 @@ class MainActivity : AppCompatActivity() {
 
             override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
                 GLES20.glViewport(0, 0, width, height)
-                // Triangle and circle are exact drawables. For them, the -1...1 range should be
-                // square. TODO find better APIs. Drawables could read glViewport at read time.
-                if (width > height) {
-                    circle.modelMatrix.clear().scaleX(height.toFloat() / width)
-                    triangle.modelMatrix.clear().scaleX(height.toFloat() / width)
-                } else if (width < height) {
-                    circle.modelMatrix.clear().scaleY(width.toFloat() / height)
-                    triangle.modelMatrix.clear().scaleY(width.toFloat() / height)
-                }
+                scene.setViewportSize(width, height)
             }
 
             override fun surfaceDestroyed(holder: SurfaceHolder?) {

--- a/demo/src/main/java/com/otaliastudios/opengl/demo/MainActivity.kt
+++ b/demo/src/main/java/com/otaliastudios/opengl/demo/MainActivity.kt
@@ -31,7 +31,6 @@ class MainActivity : AppCompatActivity() {
     private val rect = GlRect()
     private val triangle = GlTriangle()
     private val circle = GlCircle()
-    private val square = GlSquare()
 
     private val rectF = RectF()
 
@@ -113,9 +112,6 @@ class MainActivity : AppCompatActivity() {
         flatProgram!!.setColor(Color.rgb(180, 30, 30))
         circle.radius = floatValue(0.15F, 0F)
         scene.draw(flatProgram!!, circle)
-
-        flatProgram!!.setColor(Color.WHITE)
-        scene.draw(flatProgram!!, square)
 
         // Publish.
         eglSurface!!.swapBuffers()

--- a/demo/src/main/java/com/otaliastudios/opengl/demo/MainActivity.kt
+++ b/demo/src/main/java/com/otaliastudios/opengl/demo/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.otaliastudios.opengl.core.EglCore
 import com.otaliastudios.opengl.draw.GlCircle
 import com.otaliastudios.opengl.draw.GlRect
+import com.otaliastudios.opengl.draw.GlSquare
 import com.otaliastudios.opengl.draw.GlTriangle
 import com.otaliastudios.opengl.program.GlFlatProgram
 import com.otaliastudios.opengl.scene.GlScene
@@ -30,6 +31,7 @@ class MainActivity : AppCompatActivity() {
     private val rect = GlRect()
     private val triangle = GlTriangle()
     private val circle = GlCircle()
+    private val square = GlSquare()
 
     private val rectF = RectF()
 
@@ -111,6 +113,9 @@ class MainActivity : AppCompatActivity() {
         flatProgram!!.setColor(Color.rgb(180, 30, 30))
         circle.radius = floatValue(0.15F, 0F)
         scene.draw(flatProgram!!, circle)
+
+        flatProgram!!.setColor(Color.WHITE)
+        scene.draw(flatProgram!!, square)
 
         // Publish.
         eglSurface!!.swapBuffers()

--- a/library/src/main/java/com/otaliastudios/opengl/draw/GlDrawable.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/draw/GlDrawable.kt
@@ -3,9 +3,10 @@ package com.otaliastudios.opengl.draw
 
 import com.otaliastudios.opengl.core.Egloo
 import com.otaliastudios.opengl.program.GlProgram
+import com.otaliastudios.opengl.viewport.GlViewportAware
 import java.nio.FloatBuffer
 
-abstract class GlDrawable {
+abstract class GlDrawable : GlViewportAware() {
 
     /**
      * The model matrix for this object. Defaults to the

--- a/library/src/main/java/com/otaliastudios/opengl/draw/GlPolygon.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/draw/GlPolygon.kt
@@ -43,14 +43,14 @@ open class GlPolygon(private val sides: Int): Gl2dDrawable() {
         set(value) {
             field = value
             updateArray()
-            // onViewportSizeChanged()
+            onViewportSizeChanged()
         }
 
     var centerY = 0F
         set(value) {
             field = value
             updateArray()
-            // onViewportSizeChanged()
+            onViewportSizeChanged()
         }
 
     override var vertexArray = floatBufferOf((sides + 2) * coordsPerVertex)

--- a/library/src/main/java/com/otaliastudios/opengl/draw/GlPolygon.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/draw/GlPolygon.kt
@@ -3,6 +3,8 @@ package com.otaliastudios.opengl.draw
 import android.opengl.GLES20
 import com.otaliastudios.opengl.core.Egloo
 import com.otaliastudios.opengl.extensions.floatBufferOf
+import com.otaliastudios.opengl.extensions.scale
+import com.otaliastudios.opengl.extensions.translate
 import java.nio.FloatBuffer
 import kotlin.math.PI
 import kotlin.math.cos
@@ -16,35 +18,89 @@ open class GlPolygon(private val sides: Int): Gl2dDrawable() {
         }
     }
 
+    private var viewportTranslationX = 0F
+    private var viewportTranslationY = 0F
+    private var viewportScaleX = 1F
+    private var viewportScaleY = 1F
+
+    /**
+     * The polygon radius. The value 1 is half the smallest viewport dimension.
+     * For example, a [GlCircle] with radius 1 will touch the viewport borders exactly.
+     */
     var radius = 1F
         set(value) {
             field = value
-            vertexArray = generateArray()
+            updateArray()
         }
 
     var rotation = 0F
         set(value) {
             field = value % 360
-            vertexArray = generateArray()
+            updateArray()
         }
 
-    override var vertexArray: FloatBuffer = generateArray()
+    var centerX = 0F
+        set(value) {
+            field = value
+            updateArray()
+            // onViewportSizeChanged()
+        }
 
-    private fun generateArray(): FloatBuffer {
-        val array = floatBufferOf((sides + 2) * coordsPerVertex)
-        array.put(0F) // Center X
-        array.put(0F) // Center Y
+    var centerY = 0F
+        set(value) {
+            field = value
+            updateArray()
+            // onViewportSizeChanged()
+        }
+
+    override var vertexArray = floatBufferOf((sides + 2) * coordsPerVertex)
+
+    init {
+        updateArray()
+    }
+
+    private fun updateArray() {
+        val array = vertexArray
+        array.clear()
+        array.put(centerX)
+        array.put(centerY)
         var angle = rotation * (PI / 180F).toFloat()
         val step = (2F * PI).toFloat() / sides
         repeat(sides) {
-            array.put(radius * cos(angle))
-            array.put(radius * sin(angle))
+            array.put(centerX + radius * cos(angle))
+            array.put(centerY + radius * sin(angle))
             angle += step
         }
         array.put(array.get(2)) // Close the fan
         array.put(array.get(3)) // Close the fan
         array.rewind()
-        return array
+    }
+
+    override fun onViewportSizeChanged() {
+        super.onViewportSizeChanged()
+        // Undo the previous modifications.
+        modelMatrix.scale(x = 1F / viewportScaleX, y = 1F / viewportScaleY)
+        modelMatrix.translate(x = -viewportTranslationX, y = -viewportTranslationY)
+        // Compute the new ones.
+        if (viewportWidth > viewportHeight) {
+            viewportScaleX = viewportHeight.toFloat() / viewportWidth
+            viewportScaleY = 1F
+            viewportTranslationX = centerX * (1 - viewportScaleX)
+            viewportTranslationY = 0F
+        } else if (viewportWidth < viewportHeight) {
+            viewportScaleY = viewportWidth.toFloat() / viewportHeight
+            viewportScaleX = 1F
+            viewportTranslationY = centerY * (1 - viewportScaleY)
+            viewportTranslationX = 0F
+        } else {
+            viewportScaleX = 1F
+            viewportScaleY = 1F
+            viewportTranslationX = 0F
+            viewportTranslationY = 0F
+        }
+        // Apply the new ones.
+        modelMatrix.translate(x = viewportTranslationX, y = viewportTranslationY)
+        modelMatrix.scale(x = viewportScaleX, y = viewportScaleY)
     }
 
     override fun draw() {

--- a/library/src/main/java/com/otaliastudios/opengl/draw/GlSquare.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/draw/GlSquare.kt
@@ -1,8 +1,13 @@
 package com.otaliastudios.opengl.draw
 
+import kotlin.math.sqrt
+
 @Suppress("unused")
 open class GlSquare : GlPolygon(4) {
     init {
+        // We expect a square to be horizontal, which is not what GlPolygon does.
+        // We compensate here and compensate for the radius.
         rotation = 45F
+        radius = sqrt(2F)
     }
 }

--- a/library/src/main/java/com/otaliastudios/opengl/draw/GlSquare.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/draw/GlSquare.kt
@@ -1,4 +1,8 @@
 package com.otaliastudios.opengl.draw
 
 @Suppress("unused")
-open class GlSquare : GlPolygon(4)
+open class GlSquare : GlPolygon(4) {
+    init {
+        rotation = 45F
+    }
+}

--- a/library/src/main/java/com/otaliastudios/opengl/program/GlTextureProgram.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/program/GlTextureProgram.kt
@@ -28,8 +28,8 @@ open class GlTextureProgram @JvmOverloads constructor(
         val textures = IntArray(1)
         GLES20.glGenTextures(1, textures, 0)
         Egloo.checkGlError("glGenTextures")
-
         textureId = textures[0]
+
         GLES20.glActiveTexture(textureUnit)
         GLES20.glBindTexture(textureTarget, textureId)
         Egloo.checkGlError("glBindTexture $textureId")
@@ -39,6 +39,9 @@ open class GlTextureProgram @JvmOverloads constructor(
         GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
         GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
         Egloo.checkGlError("glTexParameter")
+
+        GLES20.glBindTexture(textureTarget, 0)
+        GLES20.glActiveTexture(0)
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
@@ -81,6 +84,7 @@ open class GlTextureProgram @JvmOverloads constructor(
         GLES20.glDisableVertexAttribArray(vertexPositionHandle.value)
         GLES20.glDisableVertexAttribArray(textureCoordsHandle.value)
         GLES20.glBindTexture(textureTarget, 0)
+        GLES20.glActiveTexture(0)
     }
 
     companion object {

--- a/library/src/main/java/com/otaliastudios/opengl/scene/GlScene.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/scene/GlScene.kt
@@ -6,6 +6,7 @@ import android.opengl.Matrix
 import com.otaliastudios.opengl.core.Egloo
 import com.otaliastudios.opengl.draw.GlDrawable
 import com.otaliastudios.opengl.program.GlProgram
+import com.otaliastudios.opengl.viewport.GlViewportAware
 
 /**
  * Scenes can be to draw [GlDrawable]s through [GlProgram]s.
@@ -17,7 +18,7 @@ import com.otaliastudios.opengl.program.GlProgram
  * and pass the resulting model-view-projection matrix to the program.
  */
 @Suppress("unused")
-open class GlScene {
+open class GlScene : GlViewportAware() {
 
     @Suppress("MemberVisibilityCanBePrivate")
     val projectionMatrix = Egloo.IDENTITY_MATRIX.clone()
@@ -28,14 +29,15 @@ open class GlScene {
     private val modelViewMatrix = FloatArray(16)
     private val modelViewProjectionMatrix = FloatArray(16)
 
-    private val viewportArray = IntArray(4)
-
     private fun computeModelViewProjectionMatrix(drawable: GlDrawable) {
         Matrix.multiplyMM(modelViewMatrix, 0, viewMatrix,0, drawable.modelMatrix, 0)
         Matrix.multiplyMM(modelViewProjectionMatrix, 0, projectionMatrix, 0, modelViewMatrix, 0)
     }
 
     fun draw(program: GlProgram, drawable: GlDrawable) {
+        ensureViewportSize()
+        drawable.setViewportSize(viewportWidth, viewportHeight)
+
         computeModelViewProjectionMatrix(drawable)
         program.draw(drawable, modelViewProjectionMatrix)
     }

--- a/library/src/main/java/com/otaliastudios/opengl/viewport/GlViewportAware.kt
+++ b/library/src/main/java/com/otaliastudios/opengl/viewport/GlViewportAware.kt
@@ -1,0 +1,33 @@
+package com.otaliastudios.opengl.viewport
+
+import android.opengl.GLES20
+
+abstract class GlViewportAware {
+
+    private val viewportArray = IntArray(4)
+
+    var viewportWidth: Int = -1
+        protected set
+
+    var viewportHeight: Int = -1
+        protected set
+
+    fun setViewportSize(width: Int, height: Int) {
+        if (width != viewportWidth || height != viewportHeight) {
+            viewportWidth = width
+            viewportHeight = height
+            onViewportSizeChanged()
+        }
+    }
+
+    protected open fun onViewportSizeChanged() {
+        // Do nothing.
+    }
+
+    protected fun ensureViewportSize() {
+        if (viewportHeight == -1 || viewportWidth == -1) {
+            GLES20.glGetIntegerv(GLES20.GL_VIEWPORT, viewportArray, 0)
+            setViewportSize(viewportArray[2], viewportArray[3])
+        }
+    }
+}


### PR DESCRIPTION
GlPolygon now automatically adjust their size. For  this you should call `glScene.setViewportSize` whenever the viewport size changes.

If you are not using scenes, you can use `glDrawable.setViewportSize` directly.